### PR TITLE
Replacing JdbcDialect by JdbcDialects in Step 2

### DIFF
--- a/Spark_ACID
+++ b/Spark_ACID
@@ -26,7 +26,7 @@ Step 2
 
 // Register the scala object 
 
-import org.apache.spark.sql.jdbc.JdbcDialect
+import org.apache.spark.sql.jdbc.JdbcDialects
 JdbcDialects.registerDialect(HiveDialect)
 
 Step 3

--- a/Spark_ACID
+++ b/Spark_ACID
@@ -26,7 +26,8 @@ Step 2
 
 // Register the scala object 
 
-JdbcDialect.registerDialect(HiveDialect)
+import org.apache.spark.sql.jdbc.JdbcDialect
+JdbcDialects.registerDialect(HiveDialect)
 
 Step 3
 -------


### PR DESCRIPTION
Nice hack! It worked for me.
Step 2 does not work as is though. `register` needs to be called on `JdbcDialects`. I made the fix in a fork so that people can benefit from it.